### PR TITLE
feat: Added Interview settings page functionality

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,10 +4,11 @@ import './App.css';
 import 'bootstrap/dist/css/bootstrap.min.css';
 
 import Home from './pages/Home';
-import InterviewPractice from './pages/InterviewPractice';
 import JobFinder from './pages/JobFinder';
 import ContactUs from './pages/ContactUs';
 import MyProfile from './pages/MyProfile';
+import InterviewPractice from './pages/InterviewPractice';
+import InterviewSettings from './pages/InterviewSettings';
 
 function App() {
   return (
@@ -37,7 +38,7 @@ function App() {
                 </Link>
               </li>
               <li className="nav-item">
-                <Link className="nav-link" to="/interview-practice">
+                <Link className="nav-link" to="/interview-settings">
                   Interview Practice
                 </Link>
               </li>
@@ -62,6 +63,7 @@ function App() {
 
         <Routes>
           <Route path="/" element={<Home />} />
+          <Route path="/interview-settings" element={<InterviewSettings />} />
           <Route path="/interview-practice" element={<InterviewPractice />} />
           <Route path="/job-finder" element={<JobFinder />} />
           <Route path="/contact-us" element={<ContactUs />} />

--- a/src/InterviewSettings.css
+++ b/src/InterviewSettings.css
@@ -1,0 +1,14 @@
+.container {
+    max-width: 600px;
+    margin: 0 auto;
+}
+
+.setting {
+    margin-bottom: 20px;
+}
+
+button {
+    margin: 0 10px;
+    padding: 5px 10px;
+    font-size: 16px;
+}

--- a/src/pages/InterviewSettings.js
+++ b/src/pages/InterviewSettings.js
@@ -1,0 +1,96 @@
+import React, { useState } from "react";
+import { BrowserRouter as Router, Route, Routes, Link } from 'react-router-dom';
+import '../InterviewSettings.css'; // Import the CSS file
+
+import InterviewPractice from "./InterviewPractice";
+
+function InterviewSettings() {
+    const [numQuestions, setNumQuestions] = useState(3); // Default number of questions
+    const [questionType, setQuestionType] = useState("Experiences"); // Default question type
+    const [readingTime, setReadingTime] = useState(40); // Default reading time in seconds
+    const [answerTime, setAnswerTime] = useState(120); // Default answer time in seconds
+    const [answerType, setAnswerType] = useState("Text"); // Default answer type
+
+    const questionTypes = ["Technical", "Experiences"];
+    const answerTypes = ["Text", "Voice", "Video"];
+
+    const handleArrowClick = (setter, value, delta) => {
+        setter(value + delta);
+    };
+
+    const handleTypeChange = (currentType, types, setter, delta) => {
+        const currentIndex = types.indexOf(currentType);
+        const nextIndex = (currentIndex + delta + types.length) % types.length;
+        setter(types[nextIndex]);
+    };
+
+    return (
+        <div className="container text-center mt-5">
+            <h1 className="display-4">Interview Settings</h1>
+
+            <div className="settings mt-4">
+                <div className="setting">
+                    <h4>Number of Questions: {numQuestions}</h4>
+                    <button onClick={() => handleArrowClick(setNumQuestions, numQuestions, -1)} disabled={numQuestions <= 1}>
+                        &lt;
+                    </button>
+                    <button onClick={() => handleArrowClick(setNumQuestions, numQuestions, 1)}>
+                        &gt;
+                    </button>
+                </div>
+
+                <div className="setting">
+                    <h4>Question Type: {questionType}</h4>
+                    <button onClick={() => handleTypeChange(questionType, questionTypes, setQuestionType, -1)}>
+                        &lt;
+                    </button>
+                    <button onClick={() => handleTypeChange(questionType, questionTypes, setQuestionType, 1)}>
+                        &gt;
+                    </button>
+                </div>
+
+                <div className="setting">
+                    <h4>Reading Time: {readingTime} seconds</h4>
+                    <button onClick={() => handleArrowClick(setReadingTime, readingTime, -5)} disabled={readingTime <= 5}>
+                        &lt;
+                    </button>
+                    <button onClick={() => handleArrowClick(setReadingTime, readingTime, 5)}>
+                        &gt;
+                    </button>
+                </div>
+
+                <div className="setting">
+                    <h4>Answer Time: {answerTime} seconds</h4>
+                    <button onClick={() => handleArrowClick(setAnswerTime, answerTime, -5)} disabled={answerTime <= 5}>
+                        &lt;
+                    </button>
+                    <button onClick={() => handleArrowClick(setAnswerTime, answerTime, 5)}>
+                        &gt;
+                    </button>
+                </div>
+
+                <div className="setting">
+                    <h4>Answer Type: {answerType}</h4>
+                    <button onClick={() => handleTypeChange(answerType, answerTypes, setAnswerType, -1)}>
+                        &lt;
+                    </button>
+                    <button onClick={() => handleTypeChange(answerType, answerTypes, setAnswerType, 1)}>
+                        &gt;
+                    </button>
+                </div>
+
+                <button className="btn btn-primary mt-4">
+                    <Link className="nav-link" to="/interview-practice">
+                        Start Interview
+                    </Link>
+                </button>
+            </div>
+
+            <Routes>
+                <Route path="/interview-practice" element={<InterviewPractice />} />
+            </Routes>
+        </div>
+    );
+}
+
+export default InterviewSettings;


### PR DESCRIPTION
## Context

<!-- Include contextual info that can't be found in the linked issue. Why are you making this change? -->
This pull request addresses issue #13 - the Interview Settings Functionality. Users can now set their preferred interview settings before beginning their interview practices.

Closes #13 

## What Changed?

<!-- What changes did you make? -->
- Added options for settings so that the user can freely change the Number of Questions, Question Type, Reading Time, Answer Time, and Answer Type. 
## How To Review

<!-- What (rough) order should the reviewer view your files? -->
- Test by clicking the arrow buttons in the settings page, see if the settings are being changed as desired. 
## Testing

<!-- What testing did you do, if any? -->
- I've tested all settings and edge cases, so that the 'time' settings does not go below 0 (no negative values)
## Risks
NA
<!-- Where should the reviewer focus on (if any)? -->

## Notes
NA