### PR TITLE
feat: Added a 100ms timeout to ensure clean ending of recorded video

### DIFF
--- a/src/pages/InterviewPractice.js
+++ b/src/pages/InterviewPractice.js
@@ -66,7 +66,8 @@ function InterviewPractice() {
     setTimerText(count > 0 ? count : "Time's Up");
 
     if (count <= 0) {
-      stopRecording();
+      setTimeout(()=>{
+      stopRecording();},100);
     }
   };
 
@@ -159,7 +160,9 @@ function InterviewPractice() {
           )}
 
           {videoURL && isReplay && (
-            <video src={videoURL} controls />
+            <video src={videoURL} controls   onPlay={(e) => {
+              console.log(`Video length: ${e.target.duration} seconds`);
+            }}/>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Context

There was an issue where when a recording ends due to timeout the displayed length of the recording was 1 second less than the recordings actual length.  While the displayed time was accurate when a recording is manually stopped. I discovered when using console.log the video length was roughly around 0.1 seconds shorter than the timeout e.g 19.92 seconds vs 20 seconds and the video player rounded the displayed length to 19s.


Closes #25 

## What Changed?

I added a 100ms timeout before recording is stopped so that the accurate 20 seconds is recorded.

## How To Review

Start an interview wait for it to timeout, dont press stop recording. Then play the recording once so it encodes and near the end of encoding the time should display. 

For additional reviewing you can have the console open using inspect element, the first time you click play on the recording it will say infinite seconds, the second time once its encoded it will display the actual length of the video.

## Testing

I tested it by recording multiple practices, waiting for the timout to close the recording. Then replay the video to see its displayed length. I tested various timer values including 100s and 300s and the displayed time stayed accurate.

## Risks

If this displayed time stays accurate even at greater timer lengths, and if other video functionality is affected.

## Notes
