### PR TITLE
Add user data storage and fix sonarcloud security issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ SMARTJ is built using a modern web development stack. Here are the key technolog
 
 1. Clone the repo: `git clone https://github.com/SOFTENG310-Team4/SMARTJ.git`
 2. Navigate to root directory of the Repository
-3. Create a .env file named ".env" in the root folder and add your OpenAI API key (should be in the format REACT_APP_OPENAI_API_KEY=_your key_)
+3. Create a .env file named ".env" in the root folder and add your OpenAI API key (should be in the format REACT*APP_OPENAI_API_KEY=\_your key*)
 4. Run `npm install` to install the necessary dependencies
 5. Start the MongoDB server, whether through client or `mongod` via command line
 6. Run `node server.js` to start the backend server
@@ -104,6 +104,7 @@ We welcome contributions! Please see our [Contributing Guidelines](CONTRIBUTING.
 ## Acknowledgements
 
 - We acknowledge our Initial Project developers, Anna Lin, Seth Yoo, Tony Yin, Minsung Cho, Jaewon Kim, Rusiru Dharmasekhara for their hard work
+- We acknowledge our A2 developers who continued the project, Albert Sun, Quaid Sage, Joel Kendall, Maahir Nafis, Allan Xu, Max Chen
 - Special Thanks to our Project Supervisor, Kelly Blincoe for allowing the project to flourish
 
 This project is part of the SOFTENG 310 course at the University of Auckland.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ SMARTJ is built using a modern web development stack. Here are the key technolog
 
 1. Clone the repo: `git clone https://github.com/SOFTENG310-Team4/SMARTJ.git`
 2. Navigate to root directory of the Repository
-3. Create a .env file and add a OpenAI API key (should be in the format REACT_APP_OPENAI_API_KEY=*your key*)
+3. Create a .env file named ".env" in the root folder and add your OpenAI API key (should be in the format REACT_APP_OPENAI_API_KEY=_your key_)
 4. Run `npm install` to install the necessary dependencies
 5. Start the MongoDB server, whether through client or `mongod` via command line
 6. Run `node server.js` to start the backend server

--- a/Server.js
+++ b/Server.js
@@ -124,6 +124,7 @@ app.post("/api/login", async (req, res) => {
   }
 });
 
+// Profile retrieval endpoint
 app.get("/api/profile", async (req, res) => {
   try {
     const token = req.headers.authorization.split(" ")[1];
@@ -182,6 +183,25 @@ app.put("/api/profile", upload.single("profilePicture"), async (req, res) => {
   }
 });
 
+// Delete User Endpoint
+app.delete("/api/profile", async (req, res) => {
+  try {
+    const token = req.headers.authorization.split(" ")[1];
+    const decoded = jwt.verify(token, JWT_SECRET);
+    const deletedUser = await User.findByIdAndDelete(decoded.id);
+
+    if (!deletedUser) {
+      return res.status(404).json({ message: "User not found" });
+    }
+
+    res.status(200).json({ message: "User deleted successfully" });
+  } catch (error) {
+    console.error("Error deleting user:", error);
+    res.status(500).json({ message: "Internal server error" });
+  }
+});
+
+// Upload user feedback endpoint
 app.post("/api/feedback", async (req, res) => {
   try {
     const token = req.headers.authorization.split(" ")[1];
@@ -219,6 +239,7 @@ app.post("/api/feedback", async (req, res) => {
   }
 });
 
+// Start the server
 app.listen(PORT, () => {
   console.log(`Server is running on port ${PORT}`);
 });

--- a/Server.js
+++ b/Server.js
@@ -64,13 +64,17 @@ app.post("/api/register", async (req, res) => {
     contentType: "image/png",
   };
 
+  const checkEmail = email.toString().trim().toLowerCase();
+  const checkPassword = password.toString();
+  const checkName = name.toString().trim();
+
   try {
-    const hashedPassword = await bcrypt.hash(password, 10);
+    const hashedPassword = await bcrypt.hash(checkPassword, 10);
     const newUser = new User({
-      email,
+      email: checkEmail,
       password: hashedPassword,
       profile: {
-        name,
+        name: checkName,
         profilePicture: defaultProfilePicture,
         progress: [],
         analytics: {},
@@ -96,20 +100,25 @@ app.post("/api/login", async (req, res) => {
       return res.status(400).json({ message: "Invalid email or password" });
     }
 
-    const checkEmail = email.toString();
+    const checkEmail = email.toString().trim().toLowerCase();
+    const checkPassword = password.toString();
 
-    const user = await User.findOne({ checkEmail }).lean();
+    console.log(checkEmail);
+
+    const user = await User.findOne({ email: checkEmail }).lean();
     console.log(user);
 
     if (!user) {
       return res.status(400).json({ message: "Invalid email or password" });
     }
 
-    if (await bcrypt.compare(password, user.password)) {
+    if (await bcrypt.compare(checkPassword, user.password)) {
       const token = jwt.sign({ email: user.email, id: user._id }, JWT_SECRET);
 
       console.log(token);
       return res.status(200).json({ token });
+    } else {
+      return res.status(400).json({ message: "Invalid email or password" });
     }
   } catch (error) {
     console.error(error);

--- a/Server.js
+++ b/Server.js
@@ -91,7 +91,14 @@ app.post("/api/login", async (req, res) => {
   try {
     const { email, password } = req.body;
 
-    const user = await User.findOne({ email }).lean();
+    // Making sure no malicious content is passed in
+    if (!email || !password) {
+      return res.status(400).json({ message: "Invalid email or password" });
+    }
+
+    const checkEmail = email.toString();
+
+    const user = await User.findOne({ checkEmail }).lean();
     console.log(user);
 
     if (!user) {

--- a/Server.js
+++ b/Server.js
@@ -37,6 +37,7 @@ const userSchema = new mongoose.Schema({
         {
           id: { type: String },
           date: { type: Date },
+          gptFeedback: { type: String },
           medianScore: { type: Number },
           duration: { type: Number },
           questions: [
@@ -220,6 +221,7 @@ app.post("/api/feedback", async (req, res) => {
       id: new mongoose.Types.ObjectId().toString(),
       date: new Date(date),
       medianScore: medianScore,
+      gptFeedback: feedback,
       duration: parseInt(duration, 10),
       questions: questions.split("\n").map((question, index) => ({
         question,

--- a/Server.js
+++ b/Server.js
@@ -193,10 +193,13 @@ app.post("/api/feedback", async (req, res) => {
 
     const { questions, answers, feedback, duration, date } = req.body;
 
+    const feedbackMatch = feedback.match(/\d+/);
+    const medianScore = feedbackMatch ? parseInt(feedbackMatch[0], 10) : 0;
+
     const newSession = {
       id: new mongoose.Types.ObjectId().toString(),
       date: new Date(date),
-      medianScore: parseInt(feedback.match(/\d+/)[0], 10),
+      medianScore: medianScore,
       duration: parseInt(duration, 10),
       questions: questions.split("\n").map((question, index) => ({
         question,

--- a/src/App.css
+++ b/src/App.css
@@ -33,6 +33,10 @@
   max-height: 400px;
 }
 
+.session-table-container tbody tr:hover {
+  cursor: pointer;
+}
+
 .profile-picture {
   width: 100px;
   height: 100px;

--- a/src/App.css
+++ b/src/App.css
@@ -28,11 +28,16 @@
   color: #61dafb;
 }
 
+.session-table {
+  overflow-y: scroll;
+  max-height: 300px;
+}
+
 .profile-picture {
-  width: 100px; /* Adjust the size as needed */
-  height: 100px; /* Adjust the size as needed */
-  border-radius: 50%; /* Makes the image round */
-  object-fit: cover; /* Ensures the image covers the container */
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  object-fit: cover;
   display: block;
   margin: 0 auto;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -28,9 +28,9 @@
   color: #61dafb;
 }
 
-.session-table {
+.session-table-container {
   overflow-y: scroll;
-  max-height: 300px;
+  max-height: 400px;
 }
 
 .profile-picture {

--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,7 @@ import "@fortawesome/fontawesome-free/css/all.min.css";
 import SummaryPage from "./pages/SummaryPage";
 import Register from "./pages/Register";
 import Login from "./pages/Login";
+import ProfileSession from "./pages/ProfileSession";
 import { getProfile } from "./services/ProfileService"; // Import getProfile
 import { Buffer } from "buffer";
 
@@ -128,6 +129,7 @@ function App() {
             <Route path="/contact-us" element={<ContactUs />} />
             <Route path="/my-profile" element={<MyProfile />} />
             <Route path="/summary" element={<SummaryPage />} />
+            <Route path="/ProfileSession" element={<ProfileSession />} />
           </Routes>
         </div>
 

--- a/src/__tests__/Home.test.js
+++ b/src/__tests__/Home.test.js
@@ -1,9 +1,9 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
-import Home from "../pages/Home"; // Adjust this import path as needed
-import InterviewSettings from "../pages/InterviewSettings"; // Adjust import path
-import JobFinder from "../pages/JobFinder"; // Adjust import path
+import Home from "../pages/Home";
+import InterviewSettings from "../pages/InterviewSettings";
+import JobFinder from "../pages/JobFinder";
 
 describe("Home component", () => {
   // Render the Home component with the given routes

--- a/src/__tests__/InterviewPractice.test.js
+++ b/src/__tests__/InterviewPractice.test.js
@@ -62,11 +62,14 @@ describe("InterviewPractice", () => {
     // Submit an answer
     fireEvent.click(screen.getByText("Submit Answer"));
 
-    // Click the "Finish" button
-    fireEvent.click(screen.getByText("Finish"));
+    // Use getAllByText to find all "Finish" buttons
+    const finishButtons = screen.getAllByText("Finish");
+
+    // Click the correct "Finish" button
+    fireEvent.click(finishButtons[0]);
 
     // Check if it navigated to the summary page
-    expect(screen.getByText("Mock Question")).toBeInTheDocument();
+    expect(screen.getByText("Loading feedback...")).toBeInTheDocument();
   });
 
   test("renders video recording component when answer type is 'Video'", () => {
@@ -103,10 +106,13 @@ describe("InterviewPractice", () => {
     // Submit the last answer
     fireEvent.click(screen.getByText("Submit Answer"));
 
-    // Click the "Finish" button
-    fireEvent.click(screen.getByText("Finish"));
+    // Use getAllByText to find all "Finish" buttons
+    const finishButtons = screen.getAllByText("Finish");
+
+    // Click the correct "Finish" button
+    fireEvent.click(finishButtons[0]);
 
     // Verify if it navigated to the summary
-    expect(screen.getByText("Mock Question")).toBeInTheDocument();
+    expect(screen.getByText("Loading feedback...")).toBeInTheDocument();
   });
 });

--- a/src/__tests__/JobFinder.test.js
+++ b/src/__tests__/JobFinder.test.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import JobFinder from "../pages/JobFinder"; // Adjust the import path if necessary
-
+import JobFinder from "../pages/JobFinder";
 describe("JobFinder component", () => {
   beforeEach(() => {
     render(<JobFinder />);

--- a/src/__tests__/Login.test.js
+++ b/src/__tests__/Login.test.js
@@ -35,7 +35,7 @@ describe("Login", () => {
 
   beforeAll(async () => {
     // Connect to the database
-    await mongoose.connect("mongodb://localhost:27017/smartj", {
+    await mongoose.connect("mongodb://localhost:27017/smartj_test", {
       useNewUrlParser: true,
       useUnifiedTopology: true,
     });

--- a/src/__tests__/MyProfile.test.js
+++ b/src/__tests__/MyProfile.test.js
@@ -2,70 +2,134 @@
  * @jest-environment jsdom
  */
 
-import React from "react";
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import React, { act } from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import mongoose from "mongoose";
 import MyProfile from "../pages/MyProfile";
 import Login from "../pages/Login";
-/*
+import mongoose from "mongoose";
+import bcrypt from "bcryptjs";
+import { getProfile } from "../services/ProfileService";
+
+const localStorageMock = (function () {
+  let store = {};
+
+  return {
+    getItem: function (key) {
+      return store[key];
+    },
+    setItem: function (key, value) {
+      store[key] = value.toString();
+    },
+    clear: function () {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, "localStorage", {
+  value: localStorageMock,
+});
+
 jest.mock("../services/ProfileService", () => ({
-  getProfile: jest.fn().mockResolvedValue({
-    name: "Test User",
-    profilePicture: { data: null, contentType: null },
-    analytics: { sessions: [] },
-  }),
+  getProfile: jest.fn(),
   logout: jest.fn(),
   updateProfile: jest.fn(),
+  deleteProfile: jest.fn(),
 }));
 
 describe("MyProfile", () => {
+  const setup = () => {
+    return render(
+      <MemoryRouter initialEntries={["/my-profile"]}>
+        <Routes>
+          <Route path="/my-profile" element={<MyProfile />} />
+          <Route path="/login" element={<Login />} />
+        </Routes>
+      </MemoryRouter>
+    );
+  };
+
   beforeAll(async () => {
+    // Connect to the database
     await mongoose.connect("mongodb://localhost:27017/smartj_test", {
       useNewUrlParser: true,
       useUnifiedTopology: true,
     });
+
+    // Create a test user
+    const hashedPassword = await bcrypt.hash("password123", 10);
+    await mongoose.connection.db.collection("users").insertOne({
+      email: "test@example.com",
+      password: hashedPassword,
+      profile: {
+        name: "Test User",
+        profilePicture: {
+          data: Buffer.from(""),
+          contentType: "image/png",
+        },
+        analytics: {
+          sessions: [],
+        },
+      },
+    });
   });
 
   afterAll(async () => {
-    await mongoose.connection.db.dropCollection("users");
-    await mongoose.connection.close();
+    // Clear the database of users
+    await mongoose.connection.db.collection("users").deleteMany({});
+    await mongoose.disconnect();
   });
-*/
-const setup = () => {
-  return render(
-    <MemoryRouter initialEntries={["/my-profile"]}>
-      <Routes>
-        <Route path="/my-profile" element={<MyProfile />} />
-        <Route path="/login" element={<Login />} />
-      </Routes>
-    </MemoryRouter>
-  );
-};
 
-test("renders profile details correctly", async () => {
-  setup();
-  expect(await screen.findByText("Loading...")).toBeInTheDocument();
-});
+  beforeEach(() => {
+    // Clear localStorage before each test
+    localStorage.clear();
+  });
 
-/*
-  test("allows editing profile", async () => {
+  test("renders profile details correctly", async () => {
+    getProfile.mockResolvedValueOnce({
+      name: "Test User",
+      profilePicture: {
+        data: "",
+        contentType: "image/png",
+      },
+      analytics: {
+        sessions: [],
+      },
+    });
+
+    localStorageMock.setItem("token", "fake-jwt-token");
     setup();
+
+    await waitFor(() => {
+      expect(screen.getByText("Welcome! Test User")).toBeInTheDocument();
+    });
+  });
+
+  test("allows editing profile", async () => {
+    getProfile.mockResolvedValueOnce({
+      name: "Test User",
+      profilePicture: {
+        data: "",
+        contentType: "image/png",
+      },
+      analytics: {
+        sessions: [],
+      },
+    });
+
+    localStorageMock.setItem("token", "fake-jwt-token");
+    setup();
+
     fireEvent.click(await screen.findByText("Edit"));
     expect(screen.getByLabelText("Name")).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText("Name"), {
       target: { value: "Updated User" },
     });
     fireEvent.click(screen.getByText("Save"));
-    expect(
-      await screen.findByText("Welcome! Updated User")
-    ).toBeInTheDocument();
-  });
 
-  test("logs out correctly", async () => {
-    setup();
-    fireEvent.click(await screen.findByText("Logout"));
-    expect(await screen.findByText("Login")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Welcome! Updated User")).toBeInTheDocument();
+    });
   });
 });
-*/

--- a/src/__tests__/ProfileSession.test.js
+++ b/src/__tests__/ProfileSession.test.js
@@ -1,0 +1,60 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import ProfileSession from "../pages/ProfileSession";
+
+const mockSession = {
+  id: "1",
+  date: "2023-10-01T12:00:00Z",
+  medianScore: 8,
+  gptFeedback: "Great job!",
+  duration: 120,
+  questions: [
+    {
+      question: "What is your greatest strength?",
+      answer: "My greatest strength is my adaptability.",
+    },
+    {
+      question: "Why do you want to work here?",
+      answer: "I want to work here because of the company's values.",
+    },
+  ],
+};
+
+const setup = (session) => {
+  return render(
+    <MemoryRouter
+      initialEntries={[{ pathname: "/session/1", state: { session } }]}
+    >
+      <Routes>
+        <Route path="/session/:id" element={<ProfileSession />} />
+      </Routes>
+    </MemoryRouter>
+  );
+};
+
+describe("ProfileSession", () => {
+  test("renders session details correctly", () => {
+    setup(mockSession);
+
+    expect(screen.getByText("Session Details")).toBeInTheDocument();
+    expect(screen.getByText("Duration: 120 seconds")).toBeInTheDocument();
+    expect(screen.getByText("Median Score: 8")).toBeInTheDocument();
+    expect(screen.getByText("Feedback: Great job!")).toBeInTheDocument();
+  });
+
+  test("renders questions and answers correctly", () => {
+    setup(mockSession);
+
+    mockSession.questions.forEach((qa) => {
+      expect(screen.getByText(qa.question)).toBeInTheDocument();
+      expect(screen.getByText(qa.answer)).toBeInTheDocument();
+    });
+  });
+
+  test("renders no session data message when session is not provided", () => {
+    setup(null);
+
+    expect(screen.getByText("No session data available.")).toBeInTheDocument();
+  });
+});

--- a/src/components/PerformanceChartComponent.js
+++ b/src/components/PerformanceChartComponent.js
@@ -3,9 +3,12 @@ import { Line } from "react-chartjs-2";
 import "chart.js/auto";
 
 function PerformanceChart({ sessions }) {
+  // sort the sessions by ascending date
+  sessions = sessions.sort((a, b) => new Date(a.date) - new Date(b.date));
+
   const chartData = {
     labels: sessions
-      ? sessions.map((session) => new Date(session.date).toLocaleDateString())
+      ? sessions.map((session) => new Date(session.date).toLocaleString())
       : [],
     datasets: [
       {

--- a/src/pages/InterviewPractice.js
+++ b/src/pages/InterviewPractice.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import QuestionComponent from "../components/QuestionComponent";
 import VideoRecordingComponent from "../components/VideoRecordingComponent";
@@ -25,25 +25,30 @@ function InterviewPractice() {
   const [textAnswerDuration, setTextAnswerDuration] = useState(0);
   const [currentQuestion, setCurrentQuestion] = useState(""); // State for the current question
 
+  // State to store the start time of the interview
+  const [startTime, setStartTime] = useState(null);
+
+  useEffect(() => {
+    setStartTime(Date.now());
+  }, []);
+
+  // Calculate the total duration of the interview, including reading time and answer time
+  const totalDuration = Math.floor((Date.now() - startTime) / 1000);
+
   // Function to navigate to the summary page with collected data
   function goToSummary(updatedQuestions) {
-    const duration =
-      answerType === "Text"
-        ? textAnswerDuration
-        : timeLimit - recordedChunks.length;
+    // Concatenate answers and questions
+    const concatenatedAnswers = textAnswers.join("\n");
+    const concatenatedQuestions = updatedQuestions.join("\n");
 
-   // Concatenate answers and questions
-   const concatenatedAnswers = textAnswers.join("\n");
-   const concatenatedQuestions = updatedQuestions.join("\n");
-
-   navigate("/summary", {
-     state: {
-       questions: concatenatedQuestions,
-       answers: concatenatedAnswers,
-       duration: duration,
-       date: new Date().toLocaleDateString(),
-     },
-   });
+    navigate("/summary", {
+      state: {
+        questions: concatenatedQuestions,
+        answers: concatenatedAnswers,
+        duration: totalDuration,
+        date: new Date().toLocaleDateString(),
+      },
+    });
   }
 
   // Handler for submitting text answers
@@ -67,7 +72,7 @@ function InterviewPractice() {
     const updatedQuestions = [...questions, currentQuestion];
     goToSummary(updatedQuestions);
   };
-  
+
   return (
     <div className="container text-center mt-5">
       <div className="row justify-content-center">

--- a/src/pages/MyProfile.js
+++ b/src/pages/MyProfile.js
@@ -1,5 +1,10 @@
 import React, { useEffect, useState } from "react";
-import { getProfile, logout, updateProfile } from "../services/ProfileService";
+import {
+  getProfile,
+  logout,
+  updateProfile,
+  deleteProfile,
+} from "../services/ProfileService";
 import { useNavigate } from "react-router-dom";
 import { Buffer } from "buffer";
 import PerformanceChart from "../components/PerformanceChartComponent";
@@ -8,6 +13,7 @@ function MyProfile() {
   const [profile, setProfile] = useState(null);
   const [isEditing, setIsEditing] = useState(false);
   const [profilePicture, setProfilePicture] = useState(null);
+  const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
   const navigate = useNavigate();
 
   const handleLogout = () => {
@@ -29,6 +35,19 @@ function MyProfile() {
 
   const handleFileChange = (e) => {
     setProfilePicture(e.target.files[0]);
+  };
+
+  const handleDelete = async () => {
+    await deleteProfile();
+    handleLogout();
+  };
+
+  const confirmDelete = () => {
+    setShowDeleteConfirmation(true);
+  };
+
+  const cancelDelete = () => {
+    setShowDeleteConfirmation(false);
   };
 
   useEffect(() => {
@@ -96,6 +115,9 @@ function MyProfile() {
           >
             Cancel
           </button>
+          <button className="btn btn-danger mt-3" onClick={confirmDelete}>
+            Delete Profile
+          </button>
         </div>
       ) : (
         <div>
@@ -142,6 +164,17 @@ function MyProfile() {
               </table>
             </div>
           </div>
+        </div>
+      )}
+      {showDeleteConfirmation && (
+        <div className="delete-confirmation">
+          <p>Are you sure you want to delete your profile?</p>
+          <button className="btn btn-danger" onClick={handleDelete}>
+            Yes
+          </button>
+          <button className="btn btn-secondary" onClick={cancelDelete}>
+            No
+          </button>
         </div>
       )}
     </div>

--- a/src/pages/MyProfile.js
+++ b/src/pages/MyProfile.js
@@ -70,7 +70,7 @@ function MyProfile() {
     : "images/blank-profile-picture.png";
 
   const handleSessionClick = (session) => {
-    navigate(`/session/${session.id}`, { state: { session } });
+    navigate(`/ProfileSession`, { state: { session } });
   };
 
   return (

--- a/src/pages/MyProfile.js
+++ b/src/pages/MyProfile.js
@@ -90,6 +90,12 @@ function MyProfile() {
           <button className="btn btn-primary mt-3" onClick={handleSave}>
             Save
           </button>
+          <button
+            className="btn btn-danger mt-3"
+            onClick={() => setIsEditing(false)}
+          >
+            Cancel
+          </button>
         </div>
       ) : (
         <div>

--- a/src/pages/MyProfile.js
+++ b/src/pages/MyProfile.js
@@ -115,30 +115,32 @@ function MyProfile() {
 
           <PerformanceChart sessions={profile.analytics.sessions} />
 
-          <div className="mt-5">
+          <div className="mt-5 ">
             <h3>Sessions</h3>
-            <table className="table session-table">
-              <thead>
-                <tr>
-                  <th>Date</th>
-                  <th>Median Score</th>
-                </tr>
-              </thead>
-              <tbody>
-                {profile.analytics.sessions &&
-                  profile.analytics.sessions
-                    .sort((a, b) => new Date(b.date) - new Date(a.date))
-                    .map((session) => (
-                      <tr
-                        key={session.id}
-                        onClick={() => handleSessionClick(session)}
-                      >
-                        <td>{new Date(session.date).toLocaleString()}</td>
-                        <td>{session.medianScore}</td>
-                      </tr>
-                    ))}
-              </tbody>
-            </table>
+            <div className="session-table-container">
+              <table className="table">
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th>Median Score</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {profile.analytics.sessions &&
+                    profile.analytics.sessions
+                      .sort((a, b) => new Date(b.date) - new Date(a.date))
+                      .map((session) => (
+                        <tr
+                          key={session.id}
+                          onClick={() => handleSessionClick(session)}
+                        >
+                          <td>{new Date(session.date).toLocaleString()}</td>
+                          <td>{session.medianScore}</td>
+                        </tr>
+                      ))}
+                </tbody>
+              </table>
+            </div>
           </div>
         </div>
       )}

--- a/src/pages/MyProfile.js
+++ b/src/pages/MyProfile.js
@@ -117,7 +117,7 @@ function MyProfile() {
 
           <div className="mt-5">
             <h3>Sessions</h3>
-            <table className="table">
+            <table className="table session-table">
               <thead>
                 <tr>
                   <th>Date</th>
@@ -126,15 +126,17 @@ function MyProfile() {
               </thead>
               <tbody>
                 {profile.analytics.sessions &&
-                  profile.analytics.sessions.map((session) => (
-                    <tr
-                      key={session.id}
-                      onClick={() => handleSessionClick(session)}
-                    >
-                      <td>{new Date(session.date).toLocaleDateString()}</td>
-                      <td>{session.medianScore}</td>
-                    </tr>
-                  ))}
+                  profile.analytics.sessions
+                    .sort((a, b) => new Date(b.date) - new Date(a.date))
+                    .map((session) => (
+                      <tr
+                        key={session.id}
+                        onClick={() => handleSessionClick(session)}
+                      >
+                        <td>{new Date(session.date).toLocaleString()}</td>
+                        <td>{session.medianScore}</td>
+                      </tr>
+                    ))}
               </tbody>
             </table>
           </div>

--- a/src/pages/ProfileSession.js
+++ b/src/pages/ProfileSession.js
@@ -1,0 +1,43 @@
+import React from "react";
+import { useLocation } from "react-router-dom";
+
+function ProfileSession() {
+  const location = useLocation();
+  const { session } = location.state || {};
+
+  if (!session) {
+    return <div>No session data available.</div>;
+  }
+
+  return (
+    <div className="container mt-5">
+      <h1 className="display-4 text-center mb-5">Session Details</h1>
+      <h5>Date: {new Date(session.date).toLocaleString()}</h5>
+      <h5>Duration: {session.duration} seconds</h5>
+      <h5>Median Score: {session.medianScore}</h5>
+      <h5>Feedback: {session.gptFeedback}</h5>
+
+      <div className="mt-4">
+        <h3>Questions and Answers</h3>
+        <table className="table table-bordered">
+          <thead>
+            <tr>
+              <th>Question</th>
+              <th>Answer</th>
+            </tr>
+          </thead>
+          <tbody>
+            {session.questions.map((qa, index) => (
+              <tr key={index}>
+                <td>{qa.question}</td>
+                <td>{qa.answer}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default ProfileSession;

--- a/src/pages/Register.js
+++ b/src/pages/Register.js
@@ -35,7 +35,8 @@ function Register() {
     if (validate()) {
       var response;
       response = await registerUser({ email, password, name });
-      if (response.status === 201) {
+      console.log(response);
+      if (response.message === "User created successfully") {
         navigate("/login");
       } else {
         alert("Same email already in use");

--- a/src/pages/Register.js
+++ b/src/pages/Register.js
@@ -33,9 +33,13 @@ function Register() {
   const handleRegister = async (e) => {
     e.preventDefault();
     if (validate()) {
-      await registerUser({ email, password, name });
-      // Redirect to the login page
-      navigate("/login");
+      var response;
+      response = await registerUser({ email, password, name });
+      if (response.status === 201) {
+        navigate("/login");
+      } else {
+        alert("Same email already in use");
+      }
     }
   };
 

--- a/src/pages/SummaryPage.js
+++ b/src/pages/SummaryPage.js
@@ -19,6 +19,9 @@ const SummaryPage = () => {
     date: new Date().toLocaleDateString(),
   };
 
+  const questionsArray = interviewData.questions.split("\n");
+  const answersArray = interviewData.answers.split("\n");
+
   useEffect(() => {
     const feedbackFeched = localStorage.getItem("feedbackFetched");
     // Call getFeedback to fetch feedback immediately
@@ -124,10 +127,23 @@ const SummaryPage = () => {
       )}
 
       <div className="d-flex flex-column justify-content-center align-items-center">
-        <h5 className="mb-4">Questions:</h5>
-        <pre>{interviewData.questions}</pre>
-        <h5 className="mb-4">Answers:</h5>
-        <pre>{interviewData.answers}</pre>
+        <h5 className="mb-4">Questions and Answers:</h5>
+        <table className="table table-bordered">
+          <thead>
+            <tr>
+              <th>Question</th>
+              <th>Answer</th>
+            </tr>
+          </thead>
+          <tbody>
+            {questionsArray.map((question, index) => (
+              <tr key={index}>
+                <td>{question}</td>
+                <td>{answersArray[index]}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
         <h5 className="mb-4">Duration: {interviewData.duration} seconds</h5>
         <h5 className="mb-4">Date: {interviewData.date}</h5>
 

--- a/src/pages/SummaryPage.js
+++ b/src/pages/SummaryPage.js
@@ -69,12 +69,17 @@ const SummaryPage = () => {
             messages: [
               {
                 role: "user",
-                content:
-                  "Give feedback and a number grade out of 10 to the user about these answers: " +
-                  interviewData.answers +
-                  ", to these job interview questions respectively: " +
-                  interviewData.questions +
-                  ". If the user doesn't input any answers give a 0 number grade. Give only one grade for all the answers.",
+                content: `Give feedback and a number grade out of 10 to the user about these answers: ${answersArray
+                  .map((answer, index) => `Answer ${index + 1}: ${answer}`)
+                  .join(
+                    ", "
+                  )} to these job interview questions respectively: ${questionsArray
+                  .map(
+                    (question, index) => `Question ${index + 1}: ${question}`
+                  )
+                  .join(
+                    ", "
+                  )}. If the user doesn't input any answers give a 0 number grade. Give only one grade for all the answers.`,
               },
             ],
             temperature: 0.7,

--- a/src/pages/SummaryPage.js
+++ b/src/pages/SummaryPage.js
@@ -20,19 +20,29 @@ const SummaryPage = () => {
   };
 
   useEffect(() => {
+    const feedbackFeched = localStorage.getItem("feedbackFetched");
     // Call getFeedback to fetch feedback immediately
-    getFeedback(interviewData.answers);
+    if (!feedbackFeched) {
+      getFeedback(interviewData.answers);
+      localStorage.setItem("feedbackFetched", true);
+    }
+
+    return () => {
+      localStorage.removeItem("feedbackFetched");
+    };
   }, [interviewData.answers]); // Dependency array ensures this runs only when answers change
 
   console.log(interviewData);
 
   const startNewInterview = () => {
     navigate("/interview-settings");
+    localStorage.removeItem("feedbackFetched");
   };
 
   // Navigate to the home page
   const goHome = () => {
     navigate("/");
+    localStorage.removeItem("feedbackFetched");
   };
 
   const getFeedback = async () => {

--- a/src/services/ProfileService.js
+++ b/src/services/ProfileService.js
@@ -84,6 +84,8 @@ export const saveFeedback = async (feedback, interviewData) => {
   } catch (error) {
     console.error("Failed to save feedback");
   }
+
+  return { message: "Feedback saved successfully" };
 };
 
 export const logout = () => {

--- a/src/services/ProfileService.js
+++ b/src/services/ProfileService.js
@@ -88,6 +88,18 @@ export const saveFeedback = async (feedback, interviewData) => {
   return { message: "Feedback saved successfully" };
 };
 
+export const deleteProfile = async () => {
+  const token = localStorage.getItem("token");
+  const response = await fetch("http://localhost:5000/api/profile", {
+    method: "DELETE",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  return response.json();
+};
+
 export const logout = () => {
   localStorage.removeItem("token");
 };

--- a/src/services/ProfileService.js
+++ b/src/services/ProfileService.js
@@ -74,7 +74,7 @@ export const saveFeedback = async (feedback, interviewData) => {
         answers: interviewData.answers,
         feedback: feedback,
         duration: interviewData.duration,
-        date: interviewData.date,
+        date: new Date().toISOString(),
       }),
     });
 

--- a/src/services/ProfileService.js
+++ b/src/services/ProfileService.js
@@ -60,6 +60,32 @@ export const updateProfile = async (profile, file) => {
   return response.json();
 };
 
+export const saveFeedback = async (feedback, interviewData) => {
+  try {
+    const token = localStorage.getItem("token");
+    const response = await fetch("http://localhost:5000/api/feedback", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        questions: interviewData.questions,
+        answers: interviewData.answers,
+        feedback: feedback,
+        duration: interviewData.duration,
+        date: interviewData.date,
+      }),
+    });
+
+    if (!response.ok) {
+      console.error("Failed to save feedback");
+    }
+  } catch (error) {
+    console.error("Failed to save feedback");
+  }
+};
+
 export const logout = () => {
   localStorage.removeItem("token");
 };


### PR DESCRIPTION
## Context

<!-- Include contextual info that can't be found in the linked issue. Why are you making this change? -->

Closes #77 and #75

## What Changed?

<!-- What changes did you make? -->
Created new tests, new feedback endpoint in backend server.js to upload feedback from ChatGPT to the user profile for linkage to profile. Also created new ProfileSession page that displays previous attempt data to the user. 

Fixed bug where reloading the summary would generate multiple ChatGPT requests.
Added ability to delete a user
Added cancel when editing a profile.
Made the duration of a interview based on when they enter.
Made graphs go in ascending order based on newest dates.
Added verification to ensure that users are alerted if email is already used.
Made sure if user had long answer for interview question (text) it would not break screen using a table.

Includes previous PR with sonarcloud fix with potential NoSQL injection.

## How To Review

<!-- What (rough) order should the reviewer view your files? -->

Please look at the new endpoints within the server.js for feedback. Then look at SummaryPage.js to make sure everything is logical in terms of preventing ChatGPT requests from going off multiple times. Finally look at the new tests if they are appropriate.

## Testing

<!-- What testing did you do, if any? -->
Wrote unit tests and did constant practical testing with the live database to ensure everything worked as intended.

## Risks

<!-- Where should the reviewer focus on (if any)? -->
Main file focuses are SummaryPage.js, Server.js, MyProfile.js.

## Notes
